### PR TITLE
fix(core): :bug: add missing styleClasses props in CoreTypographyBody…

### DIFF
--- a/package/components/dataDisplay/CoreTypographyBody2.js
+++ b/package/components/dataDisplay/CoreTypographyBody2.js
@@ -49,6 +49,8 @@ export default function CoreTypographyBody2(props) {
       variant="body2"
       paragraph={true}
       gutterBottom={true}
+      styleClasses={styleClasses}
+
     />
   );
 }


### PR DESCRIPTION
Add missing 'styleClasses' props in CoreTypographyBody2.js

ref: #100