### PR TITLE
fix(core): :bug: Spell mistake of the validProps array in CoreListItemButton comp

### DIFF
--- a/package/components/dataDisplay/CoreListItemButton.js
+++ b/package/components/dataDisplay/CoreListItemButton.js
@@ -11,7 +11,7 @@ export default function CoreListItemButton(props) {
   return <NativeListItemButton {...props} />;
 }
 
-CoreListItemButton.invalidProps = [
+CoreListItemButton.validProps = [
   {
     description: "Defines the align-items style property.",
     name       : "alignItems",

--- a/package/components/inputs/CoreButton.js
+++ b/package/components/inputs/CoreButton.js
@@ -9,8 +9,6 @@ import { sanitizeComponentProps } from "../../utils/componentUtil";
 
 export default function CoreButton(props) {
   props = sanitizeComponentProps(CoreButton, props);
-  console.log("btn props", props);
-
   return <NativeButton {...props} />;
 }
 


### PR DESCRIPTION
correct the validProps array of CoreListItemButton comp, validProps was getting undefined due to the wrong spell of the validProps array.

ref: #195