### PR TITLE
fix(core): 🐛 maximum update depth exceeded in PageContainer.js

### DIFF
--- a/package/components/surfaces/DefaultAppBarContent.js
+++ b/package/components/surfaces/DefaultAppBarContent.js
@@ -28,7 +28,7 @@ export default function DefaultAppBarContent(props) {
   const dispatch = useDispatch();
   let { config } = React.useContext(WrappidDataContext);
   let { appLogo } = React.useContext(CoreResourceContext);
-  const auth = useSelector((state) => state.auth);
+  const auth = useSelector((state) => state?.auth || {});
   const mdm = useSelector((state) => state.mdm);
   const [getSettingMetaFlag, setGetSettingMetaFlag] = useState(false);
   const [platform, setPlatform] = useState(null);

--- a/package/layout/PageContainer.js
+++ b/package/layout/PageContainer.js
@@ -70,7 +70,7 @@ export default function PageContainer(props) {
 
   React.useEffect(()=>{
     dispatch({ type: RESET_FROM_STATE });
-  }, [route]);
+  }, [sessionExpired]);
 
   React.useEffect(() => {
     if (sessionExpired && !sessionDetail) {
@@ -92,7 +92,7 @@ export default function PageContainer(props) {
     ) {
       dispatch({ type: SESSION_RECALLED });
     }
-  });
+  }, []);
 
   React.useEffect(() => {
     // -- console.log("LOCATION SAVE______", location);


### PR DESCRIPTION
returning an empty object when a state is not returned seems to fix the problem

wrappid/core#219

A solution to the issue was found in changing the following line in Line 29 of PageContainer.js :

 const { uid, sessionExpired, sessionDetail } = useSelector((state) => state.auth );

The code can be changed to :

 const { uid, sessionExpired, sessionDetail } = useSelector((state) => state?.auth || {});

Returning an empty object when a state is not returned seems to fix the problem.
