### PR TITLE
feat(core): :sparkles: styling tab headers for CoreCustomTabs

### DIFF
--- a/package/components/navigation/CoreCustomTabs.js
+++ b/package/components/navigation/CoreCustomTabs.js
@@ -39,11 +39,12 @@ export default function CoreCustomTabs(props) {
 
   // -- console.log("TAB REF T", tabRef);
   return (
-    <>
+    <> 
       <CoreTabHead
         tabsContent={tabsContent}
         handleChange={handleChange}
         tabRef={tabRef}
+        styleClasses={props?.tabHeadClasses}
         tabValue={tabValue}
       />
 


### PR DESCRIPTION
**Description**
support added for CoreCustomTabs's CoreTabHead styling with tabHeadClasses props

ref: ##233