### PR TITLE
fix(core): :lipstick: component CoreAppDrawer's default menu icon alignment

### DIFF
--- a/package/components/surfaces/DefaultAppBarContent.js
+++ b/package/components/surfaces/DefaultAppBarContent.js
@@ -114,12 +114,11 @@ export default function DefaultAppBarContent(props) {
         >
           {leftMenuEnabled && (
             <CoreIconButton
-              styleClasses={appBarTextStyle}
+              styleClasses={[...appBarTextStyle, CoreClasses.MARGIN.ML_N2]}
               aria-label="open drawer"
               onClick={handleDrawer}
               edge="start"
               disabled={!auth?.uid}
-              // sx={{ marginLeft: "-16px" }}
             >
               <CoreIcon>menu</CoreIcon>
             </CoreIconButton>


### PR DESCRIPTION
component CoreAppDrawer's default menu icon, margin set to ML_N2

Ref: #244