### PR TITLE
fix(core): :bug: there is bug that is happening in guide modules in CoreList which is occuring due to a file in core modules

### DIFF
--- a/package/components/dataDisplay/CoreListSubheader.js
+++ b/package/components/dataDisplay/CoreListSubheader.js
@@ -1,15 +1,17 @@
-/* eslint-disable import/no-unresolved */
+// eslint-disable-next-line no-unused-vars, unused-imports/no-unused-imports
+import React from "react";
 
+// eslint-disable-next-line import/no-unresolved
 import { NativeListSubheader } from "@wrappid/native";
 
 import { sanitizeComponentProps } from "../../utils/componentUtil";
 
-export default function CoreListItemSubheader(props) {
-  props = sanitizeComponentProps(CoreListItemSubheader, props);
+export default function CoreListSubheader(props) {
+  props = sanitizeComponentProps(CoreListSubheader, props);
   return <NativeListSubheader {...props} />;
 }
 
-CoreListItemSubheader.validProps = [
+CoreListSubheader.validProps = [
   {
     description:
       "The color of the component. It supports both default and custom theme colors, which can be added as shown in the palette customization guide.",
@@ -71,4 +73,4 @@ CoreListItemSubheader.validProps = [
   },
 ];
 
-CoreListItemSubheader.invalidProps = [];
+CoreListSubheader.invalidProps = [];


### PR DESCRIPTION
## Description

There was a error that was happening in guide modules documentation in corelist which was occurring due the naming of a function in CoreListSubheader whose name was CoreListItemSubheader and it is changed to CoreListSubheader and also due to the react that was not imported in that file. This bug has been fixed completely.

Ref: #276


## Related Issues

Due to this issue the whole CoreList docomentation was breaking down which has been resolved
## Fixed Image
![Screenshot 2024-08-07 182916](https://github.com/user-attachments/assets/7e41141c-167d-4ff8-9496-e39d8e7b5cda)
