### PR TITLE
feat(core): :sparkles: clickable CoreChip on onClick

### DIFF
--- a/package/components/dataDisplay/CoreChip.js
+++ b/package/components/dataDisplay/CoreChip.js
@@ -9,37 +9,9 @@ import { sanitizeComponentProps } from "../../utils/componentUtil";
 export default function CoreChip(props) {
   props = sanitizeComponentProps(CoreChip, props);
 
-  const {
-    avatar,
-    clickable,
-    color,
-    component,
-    deleteIcon,
-    showZero,
-    icon,
-    label,
-    onDelete,
-    size,
-    skipFocusWhenDisabled,
-    variant,
-    disabled
-  } = props;
-
   return (
-    <NativeChip 
-      avatar={avatar}
-      clickable={clickable}
-      color={color}
-      component={component}
-      deleteIcon={deleteIcon}
-      showZero={showZero}
-      icon={icon}
-      label={label}
-      onDelete={onDelete}
-      size={size}
-      skipFocusWhenDisabled={skipFocusWhenDisabled}
-      variant={variant}
-      disabled={disabled}
+    <NativeChip
+      {...props}
     />
   );
 }
@@ -55,8 +27,9 @@ CoreChip.validProps = [
     name       : "clickable",
     types      : [
       {
-        type       : "boolean",
-        validValues: [true, false],
+        isDefaultType: true,
+        type         : "boolean",
+        validValues  : [true, false],
       },
     ],
   },


### PR DESCRIPTION
## Description

fix clickable functionality on onClick for CoreChip, by spreading props

## Related Issues

#282

## Testing
<!-- Describe the testing steps you have taken to ensure that your changes work as expected -->

## Checklist

- [ ] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [ ] My code follows the project's style guidelines and best practices.
- [ ] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [ ] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)
<!-- Include screenshots or animated GIFs to visually demonstrate the changes, if applicable -->

## Additional Notes

<!--Feel free to add any other relevant information that might be helpful to reviewers.-->

## Reviewers

<!--Tag any specific individuals or teams you'd like to review this pull request.

Thank you for your contribution!-->

---

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
