### PR TITLE
feat(core): :sparkles: adding new props and varient

### DIFF
--- a/package/components/dataDisplay/CoreList.js
+++ b/package/components/dataDisplay/CoreList.js
@@ -126,6 +126,18 @@ CoreList.validProps = [
         ] 
       }
     ]
+  },
+  {
+    description:
+      "The content of the subheader, normally ListSubheader.",
+    name : "variant",
+    types: [
+      {
+        default    : "DEFAULT",
+        type       : "string",
+        validValues: ["DEFAULT", "HTML"] 
+      }
+    ],
   }
 ];
 


### PR DESCRIPTION
## Description
varient props is added to verify listType is going to work or not



```
<CoreList varient="HTML" listType="AUTO">
      <CoreListItems>
              <CoreListItemsText primary="Enter your text"> 
      <CoreListItems>
<CoreList>

```
Ref: #284

