### PR TITLE
feat(core): :sparkles: alt props text CoreImage

### DIFF
--- a/package/components/dataDisplay/CoreImage.js
+++ b/package/components/dataDisplay/CoreImage.js
@@ -10,18 +10,19 @@ export default function CoreImage(props) {
   props = sanitizeComponentProps(CoreImage, props);
   return <NativeImage {...props} />;
 }
+
+CoreImage.displayName = "CoreImage";
+
 CoreImage.validProps = [
   {
-    name : "src",
-    types: [{ type: "string" }]
+    description: "The source of the image.",
+    name       : "src",
+    types      : [{ type: "string" }]
   },
   {
-    name : "height",
-    types: [{ type: "number" }]
-  },
-  {
-    name : "width",
-    types: [{ type: "number" }]
+    description: "The alternative text of the image.",
+    name       : "alt",
+    types      : [{ type: "string" }]
   }
 ];
 CoreImage.invalidProps = ["style", "sx", "classes"];


### PR DESCRIPTION
## Description

This PR adds support for `alt` props text in CoreImage component".

## Related Issues
- [x] #286 
- [ ] wrappid/guide-module#186

## Testing
<!-- Describe the testing steps you have taken to ensure that your changes work as expected -->

## Checklist

- [x] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [x] My code follows the project's style guidelines and best practices.
- [x] I have updated the documentation if necessary.
- [x] I have added or updated relevant comments in my code.
- [x] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)
<!-- Include screenshots or animated GIFs to visually demonstrate the changes, if applicable -->

## Additional Notes

<!--Feel free to add any other relevant information that might be helpful to reviewers.-->

## Reviewers

<!--Tag any specific individuals or teams you'd like to review this pull request.

Thank you for your contribution!-->

---

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
