### PR TITLE
bugfix: name to displayName

### DIFF
--- a/package/components/dataDisplay/CoreAvatar.js
+++ b/package/components/dataDisplay/CoreAvatar.js
@@ -15,7 +15,7 @@ export default function CoreAvatar(props) {
 
   return <NativeAvatar {...props} src={src} />;
 }
-CoreAvatar.name = "CoreAvatar";
+CoreAvatar.displayName = "CoreAvatar";
 CoreAvatar.validProps = [
   {
     description: "Used in combination with src or srcSet to provide an alt attribute for the rendered img element.",


### PR DESCRIPTION
## Description

name can't be accessible in react of any component so we need to make changes for displayName

## Related Issues

#305

## Testing
<!-- Describe the testing steps you have taken to ensure that your changes work as expected -->

## Checklist

- [x] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [x] My code follows the project's style guidelines and best practices.
- [ ] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [ ] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)
<!-- Include screenshots or animated GIFs to visually demonstrate the changes, if applicable -->

## Additional Notes

<!--Feel free to add any other relevant information that might be helpful to reviewers.-->

## Reviewers

<!--Tag any specific individuals or teams you'd like to review this pull request.

Thank you for your contribution!-->

---

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
