### PR TITLE
feat(core): :sparkles: dataDisplay/CoreChip support for href and target

### DIFF
--- a/package/components/dataDisplay/CoreChip.js
+++ b/package/components/dataDisplay/CoreChip.js
@@ -16,6 +16,8 @@ export default function CoreChip(props) {
   );
 }
 
+CoreChip.displayName = "CoreChip";
+
 CoreChip.validProps = [
   {
     description: "The Avatar element to display.",
@@ -139,6 +141,28 @@ CoreChip.validProps = [
       },
     ],
   },
+  {
+    description: "The href of the link.",
+    name       : "href",
+    types      : [{ type: "string" }],
+  },
+  {
+    description: "The target of the link.",
+    name       : "target",
+    types      : [
+      {
+        default    : "_self",
+        type       : "string",
+        validValues: [
+          "_blank",
+          "_parent",
+          "_top",
+          "_self",
+          "_unfencedTop"
+        ]
+      }
+    ],
+  }
 ];
 
 CoreChip.invalidProps = [];


### PR DESCRIPTION
## Description

This PR adds `href` and `target` in valid props.
ref: #282

## Related Issues

<!--List any related issues that this pull request addresses. -->

## Testing
<!-- Describe the testing steps you have taken to ensure that your changes work as expected -->

## Checklist

- [ ] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [ ] My code follows the project's style guidelines and best practices.
- [ ] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [ ] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)
<!-- Include screenshots or animated GIFs to visually demonstrate the changes, if applicable -->

## Additional Notes

<!--Feel free to add any other relevant information that might be helpful to reviewers.-->

## Reviewers

<!--Tag any specific individuals or teams you'd like to review this pull request.

Thank you for your contribution!-->

---

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
