### PR TITLE
feat(core): :sparkles: update code of CoreLinearProgress

### DIFF
--- a/package/components/feedback/CoreLinearProgress.js
+++ b/package/components/feedback/CoreLinearProgress.js
@@ -8,7 +8,7 @@ import { sanitizeComponentProps } from "../../utils/componentUtil";
 
 export default function CoreLinearProgress(props) {
   props = sanitizeComponentProps(CoreLinearProgress, props);
-  const { color, value, valueBuffer, variant } = props;
+  const { color, value, valueBuffer, variant, showPercentage } = props;
 
   return (
     <NativeLinearProgress
@@ -16,6 +16,7 @@ export default function CoreLinearProgress(props) {
       value={value}
       valueBuffer={valueBuffer}
       variant={variant}
+      showPercentage={showPercentage}
     ></NativeLinearProgress>
   );
 }
@@ -53,6 +54,16 @@ CoreLinearProgress.validProps = [
         default    : "indeterminate",
         type       : "string",
         validValues: ["sxbuffer", "determinate", "indeterminate", "query"],
+      },
+    ],
+  },
+  {
+    description: "Determines whether the percentage should be displayed next to the progress bar.",
+    name       : "showPercentage",
+    types      : [
+      {
+        default: false,
+        type   : "boolean",
       },
     ],
   },

--- a/package/components/feedback/CoreLinearProgress.js
+++ b/package/components/feedback/CoreLinearProgress.js
@@ -8,15 +8,12 @@ import { sanitizeComponentProps } from "../../utils/componentUtil";
 
 export default function CoreLinearProgress(props) {
   props = sanitizeComponentProps(CoreLinearProgress, props);
-  const { color, value, valueBuffer, variant, showPercentage } = props;
+  const { labelWidth = 35, ...restProps } = props;
 
   return (
     <NativeLinearProgress
-      color={color}
-      value={value}
-      valueBuffer={valueBuffer}
-      variant={variant}
-      showPercentage={showPercentage}
+      {...restProps}
+      labelWidth={labelWidth}
     ></NativeLinearProgress>
   );
 }
@@ -58,14 +55,24 @@ CoreLinearProgress.validProps = [
     ],
   },
   {
-    description: "Determines whether the percentage should be displayed next to the progress bar.",
-    name       : "showPercentage",
+    description: "Determines whether the label should be displayed next to the progress bar.",
+    name       : "showLabel",
     types      : [
       {
         default: false,
         type   : "boolean",
       },
     ],
+  },
+  { 
+    description: "This prop allows you to set the width of progress width",
+    name       : "labelWidth",
+    types      : [
+      {
+        default: 35,
+        type   : "number" 
+      }
+    ]
   },
 ];
 CoreLinearProgress.invalidProps = [];


### PR DESCRIPTION
## Description
Update the code, where I implemented two props(showLabel, labelWidth), those props help display the label of linear progress, if showLabel is true then the label is shown, also labelWidth prop is used for the width of the label, by default it is 35px, if any users need more width or less they can customize it as well.
Ref: https://github.com/wrappid/core/issues/332 

## Related Issues

https://github.com/wrappid/native-web/issues/114

## Testing
I pass those props in the code of this(CoreLinearProgress.docs.js) file, and the code works properly.

## Checklist

- [X] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [X] My code follows the project's style guidelines and best practices.
- [X] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [ ] I have resolved any merge conflicts in my branch.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/47dfa5f2-9566-49b2-8993-1c01f1f85723)

## Additional Notes

## Reviewers


## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
