### PR TITLE
feat(core): :sparkles: add validProps in CoreRating

### DIFF
--- a/package/components/inputs/CoreRating.js
+++ b/package/components/inputs/CoreRating.js
@@ -12,19 +12,57 @@ export default function CoreRating(props) {
 }
 CoreRating.validProps = [
   {
-    description: "Default selected stars",
+    description: "The default value. Use when the component is not controlled.",
     name       : "defaultValue",
-    types      : [{ default: "3", type: "number" }],
+    types      : [{ default: null, type: "number" }],
   },
   {
     description: "If true, the component is disabled.",
     name       : "disabled",
-    types      : [{ default: false, type: "boolean" }],
+    types      : [{ default: false, type: "boolean", validValues: [true, false] }],
   },
   {
-    description: "Removes all hover effects and pointer events.",
-    name       : "readOnly",
-    types      : [{ default: false, type: "boolean" }]
+    description: "The icon to display when empty.",
+    name       : "emptyIcon",
+    types      : [{ default: "<StarBorder fontSize=inherit/>", type: "node" }],
+  },
+  {
+    description: "The label read when the rating input is empty.",
+    name       : "emptyLabelText",
+    types      : [{ default: "Empty", type: "node" }],
+  },
+  {
+    description:
+      "Accepts a function which returns a string value that provides a user-friendly name for the current value of the rating. This is important for screen reader users.For localization purposes, you can use the provided translations.Signature:function(value: number) => stringvalue The rating label's value to format.",
+    name : "getLabelText",
+    types: [
+      {
+        default:
+          "function defaultLabelText(value) { return `${value || '0'} Star${value !== 1 ? 's' : ''}`; }",
+        type: "function",
+      },
+    ],
+  },
+  {
+    description: "If true, only the selected icon will be highlighted.",
+    name       : "highlightSelectedOnly",
+    types      : [{ default: false, type: "boolean", validValues: [true, false] }],
+  },
+  {
+    description: "The icon to display.",
+    name       : "icon",
+    types      : [{ default: "<Star fontSize=inherit/>", type: "node" }],
+  },
+  {
+    description: "The component containing the icon.",
+    name       : "IconContainerComponent",
+    types      : [
+      {
+        default:
+          "function IconContainer(props) { const { value, ...other } = props; return <span {...other} />; }",
+        type: "elementType",
+      },
+    ],
   },
   {
     description: "Maximum rating.",
@@ -32,21 +70,43 @@ CoreRating.validProps = [
     types      : [{ default: 5, type: "number" }],
   },
   {
-    description: "The minimum increment value change allowed..",
+    description:
+      "The name attribute of the radio input elements. This input name should be unique within the page. Being unique within a form is insufficient since the name is used to generated IDs.",
+    name : "name",
+    types: [{ type: "string" }],
+  },
+  {
+    description:
+      "Callback fired when the value changes.Signature: function(event: React.SyntheticEvent, value: number | null) => void | event The event source of the callback | value The new value.",
+    name : "onChange",
+    types: [{ type: "function" }],
+  },
+  {
+    description:
+      "Callback function that is fired when the hover state changes.Signature:function(event: React.SyntheticEvent, value: number) => void | event The event source of the callback | value The new value.",
+    name : "onChangeActive",
+    types: [{ type: "function" }],
+  },
+  {
+    description: "The minimum increment value change allowed.",
     name       : "precision",
     types      : [{ default: 1, type: "number" }],
   },
   {
-    description: "The size of the component",
-    name       : "size",
-    types      : [{ default: "medium", type: "'small'| 'medium'| 'large'| string " }],
+    description: "Removes all hover effects and pointer events.",
+    name       : "readOnly",
+    types      : [{ default: false, type: "boolean", validValues: [true, false] }],
   },
   {
-    description: "The rating value, The ref is forwarded to the root element.",
+    description: "The size of the component.",
+    name       : "size",
+    types      : [{ default: "medium", type: "string", validValues: ["small", "medium", "large"] }],
+  },
+  {
+    description: "The rating value.",
     name       : "value",
     types      : [{ type: "number" }],
   },
 ];
 CoreRating.invalidProps = [];
 
-//not tested props -> getLabelText,onChangeActive,emptyIcon,icon,IconContainerComponent,highlightSelectedOnly


### PR DESCRIPTION
## Description
In CoreRating a few valid pops are not defined, which affects CoreRating's behaviour,  so I add those valid props.
Ref: #360

## Related Issues
https://github.com/wrappid/guide-module/issues/292

## Testing
I use these props in CoreRating.docs.js, those are works as well.

## Checklist

- [X] I have performed a thorough self-review of my code.
- [X] I have added or updated relevant tests for my changes.
- [X] My code follows the project's style guidelines and best practices.
- [X] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [ ] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)

## Additional Notes

## Reviewers

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
