### PR TITLE
feat(core): :sparkles: update valid props of CoreCard

### DIFF
--- a/package/components/surfaces/CoreCard.js
+++ b/package/components/surfaces/CoreCard.js
@@ -19,10 +19,6 @@ CoreCard.validProps = [
     name       : "raised",
     types      : [{ default: false, type: "boolean", validValues: [true, false] }],
   },
-  {
-    name : "onClick", 
-    types: [{ type: "function" }], 
-  },
 ];
 
 CoreCard.invalidProps = [];

--- a/package/components/surfaces/CoreCard.js
+++ b/package/components/surfaces/CoreCard.js
@@ -4,6 +4,7 @@ import React from "react";
 // eslint-disable-next-line import/no-unresolved
 import { NativeCard } from "@wrappid/native";
 
+import CorePaper from "./CorePaper";
 import { sanitizeComponentProps } from "../../utils/componentUtil";
 
 export default function CoreCard(props) {
@@ -12,13 +13,14 @@ export default function CoreCard(props) {
   return <NativeCard {...props} />;
 }
 CoreCard.validProps = [
+  ...CorePaper.validProps,
   {
     description: "If true, the card will use raised styling.",
     name       : "raised",
     types      : [{ default: false, type: "boolean", validValues: [true, false] }],
   },
   {
-    name : "onClick", /// we have already a onClick props available in CoreButton but it's starting with Capital 'O' that's need to be changed to present 'onClicl' props.
+    name : "onClick", 
     types: [{ type: "function" }], 
   },
 ];


### PR DESCRIPTION
## Description
As we can use the valid pops of CorePaper in CoreCard, I added those props to CoreCard.
Ref: #364

## Related Issues

https://github.com/wrappid/guide-module/issues/296

## Testing
I use those valid props in CoreCard.docs.js, those are working.

## Checklist

- [X] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [X] My code follows the project's style guidelines and best practices.
- [X] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [ ] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)

## Additional Notes

## Reviewers

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
