### PR TITLE
feat(global): :sparkles: corelist sub components comes in a grid format

### DIFF
--- a/package/components/dataDisplay/CoreList.js
+++ b/package/components/dataDisplay/CoreList.js
@@ -132,7 +132,18 @@ CoreList.validProps = [
       {
         default    : "DEFAULT",
         type       : "string",
-        validValues: ["DEFAULT", "HTML"] 
+        validValues: ["DEFAULT", "HTML", "GRID"] 
+      }
+    ],
+  },
+  {
+    description: "The content of the subheader, normally ListSubheader.",
+    name       : "gridItemComponent",
+    types      : [
+      {
+        default    : "2",
+        type       : "string",
+        validValues: ["2", "3", "4", "6"] 
       }
     ],
   }


### PR DESCRIPTION
## Description

two new props has been introduced in corelist that can show the corelistitem in grid format an a prop that show how many section it can be divided

Ref: #377

## Related Issues

<!--List any related issues that this pull request addresses. -->

## Testing
<!-- Describe the testing steps you have taken to ensure that your changes work as expected -->

## Checklist

- [ ] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [ ] My code follows the project's style guidelines and best practices.
- [ ] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [ ] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)
<!-- Include screenshots or animated GIFs to visually demonstrate the changes, if applicable -->

## Additional Notes

<!--Feel free to add any other relevant information that might be helpful to reviewers.-->

## Reviewers

<!--Tag any specific individuals or teams you'd like to review this pull request.

Thank you for your contribution!-->

---

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
