### PR TITLE
feature(core): more than 2 icon replace with 3 dot

### DIFF
--- a/package/components/surfaces/CoreToolBox.js
+++ b/package/components/surfaces/CoreToolBox.js
@@ -58,6 +58,21 @@ CoreToolBox.validProps = [
         validValues: [] 
       }
     ]
+  },
+  {
+    description: "This is for expand handelling",
+    name       : "expandProp",
+    types      : [
+      {
+        default: true,
+        type   : "boolean"
+      }
+    ]
+  },
+  {
+    description: "The toolboxActionButton to display in the card header.",
+    name       : "toolboxActionButton",
+    types      : [{ type: "node" }],
   }
 ];
 


### PR DESCRIPTION
## Description

we can now pass icons in props, also if we have more than 2 icons, then replace them with 3 dots, if we click on that 3 dots then those icons appear. Also, this component needs more updation, I am giving this PR unintentionally as it related to other commits in other repo.

## Related Issues

Ref: #380

## Testing
<!-- Describe the testing steps you have taken to ensure that your changes work as expected -->

## Checklist

- [ ] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [ ] My code follows the project's style guidelines and best practices.
- [ ] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [ ] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)
<!-- Include screenshots or animated GIFs to visually demonstrate the changes, if applicable -->

## Additional Notes

<!--Feel free to add any other relevant information that might be helpful to reviewers.-->

## Reviewers

<!--Tag any specific individuals or teams you'd like to review this pull request.

Thank you for your contribution!-->

---

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
