### PR TITLE
enhancement: enable grid view for CoreList component

### DIFF
--- a/package/components/dataDisplay/CoreList.js
+++ b/package/components/dataDisplay/CoreList.js
@@ -132,38 +132,14 @@ CoreList.validProps = [
       {
         default    : "DEFAULT",
         type       : "string",
-        validValues: ["DEFAULT", "HTML", "GRID"] 
+        validValues: ["DEFAULT", "HTML", "grid"] 
       }
     ],
   },
   {
-    description: "The content of the subheader, normally ListSubheader.",
-    name       : "gridItemComponent",
-    types      : [
-      {
-        default    : "default",
-        type       : "string",
-        validValues: [
-          "default",
-          "xs",
-          "s",
-          "m",
-          "l",
-          "xl"
-        ] 
-      }
-    ],
-  },
-  {
-    description: "The content of the subheader, normally ListSubheader.",
-    name       : "borderList",
-    types      : [
-      {
-        default    : false,
-        type       : "boolean",
-        validValues: [true, false]
-      }
-    ],
+    description: "This helps to add gridProps into the children of corelist.",
+    name       : "itemGridProps",
+    types      : [{ type: "object" }],
   }
 ];
 

--- a/package/components/dataDisplay/CoreList.js
+++ b/package/components/dataDisplay/CoreList.js
@@ -140,6 +140,11 @@ CoreList.validProps = [
     description: "This helps to add gridProps into the children of corelist.",
     name       : "itemGridProps",
     types      : [{ type: "object" }],
+  },
+  {
+    description: "This helps to add StyleClasses into the children of corelist.",
+    name       : "itemStylesProps",
+    types      : [{ type: "object" }],
   }
 ];
 

--- a/package/components/dataDisplay/CoreList.js
+++ b/package/components/dataDisplay/CoreList.js
@@ -141,9 +141,27 @@ CoreList.validProps = [
     name       : "gridItemComponent",
     types      : [
       {
-        default    : "2",
+        default    : "default",
         type       : "string",
-        validValues: ["2", "3", "4", "6"] 
+        validValues: [
+          "default",
+          "xs",
+          "s",
+          "m",
+          "l",
+          "xl"
+        ] 
+      }
+    ],
+  },
+  {
+    description: "The content of the subheader, normally ListSubheader.",
+    name       : "borderList",
+    types      : [
+      {
+        default    : false,
+        type       : "boolean",
+        validValues: [true, false]
       }
     ],
   }

--- a/package/components/dataDisplay/CoreList.js
+++ b/package/components/dataDisplay/CoreList.js
@@ -145,6 +145,17 @@ CoreList.validProps = [
     description: "This helps to add StyleClasses into the children of corelist.",
     name       : "itemStylesProps",
     types      : [{ type: "object" }],
+  },
+  {
+    description: "This helps to add StyleClasses into the children of corelist.",
+    name       : "toolbox",
+    types      : [
+      {
+        default    : true,
+        type       : "boolean",
+        validValues: [true, false]
+      }
+    ],
   }
 ];
 


### PR DESCRIPTION
Enable grid view for CoreList component, so that all children (CoreListItem) appear on grid.

The new variant (GRID) should also support the following:

 

- [ ] props for number of items in every row for different screen sizes (default, sm, md,...)
- [ ] props to enable toolbar
- [ ] toolbar to navigate between LIST and GRID, preferably multiple GRID sizes (like 3 items per row OR 4 items per row OR ...)
- [ ]  the toolbar should also have a search (this will only search in the already rendered items)
- [ ] Support lazy loading for the CoreList
- [ ]  CoreListSubHeader is getting wrapped
- [ ]  if a array is sent inside the list it will create a list